### PR TITLE
Network layer + beginning of API layer

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,9 @@
 {
   "presets": ["react", "es2015"],
-  "plugins": ["transform-es2015-destructuring", "transform-object-rest-spread"]
+  "plugins": [
+    "transform-es2015-destructuring",
+    "transform-object-rest-spread", 
+    "syntax-class-properties",
+    "transform-class-properties"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "babel-eslint": "7.2.3",
     "babel-jest": "20.0.3",
     "babel-loader": "7.1.2",
+    "babel-plugin-syntax-class-properties": "^6.13.0",
+    "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-es2015-destructuring": "^6.23.0",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-es2015": "^6.24.1",
@@ -122,7 +124,9 @@
     ],
     "plugins": [
       "transform-es2015-destructuring",
-      "transform-object-rest-spread"
+      "transform-object-rest-spread",
+      "syntax-class-properties",
+      "transform-class-properties"
     ]
   },
   "eslintConfig": {

--- a/src/api/admin_client/index.js
+++ b/src/api/admin_client/index.js
@@ -1,0 +1,38 @@
+import Request from '../utils/request_api';
+
+/**
+ * This is our API Layer for our Admin Service.  All requests related to our Admin service
+ * will pass through here.  The API Layer utilizes the Network layer to make requests.
+ */
+
+
+const ADMIN_HOST = 'http://localhost:3001/admin';
+
+class AdminClient {
+  
+  // using singleton design pattern here
+  // there should only exist one instance of AdminClient for our entire app
+  static singleton = null;
+
+  static getSingleton() {
+    if (AdminClient.singleton === null) {
+      AdminClient.singleton = new AdminClient();
+    }
+
+    return this.singleton;
+  }
+
+  /**
+   * 
+   * @param {Object} param0 
+   * @returns {Promise}
+   */
+  createAdmin({firstName, lastName, username, email, password}) {
+    const URL = `${ADMIN_HOST}/`;
+    const params = {firstName, lastName, username, email, password};
+
+    return Request.post(URL, params);
+  }
+}
+
+export default AdminClient;

--- a/src/api/utils/request_api.js
+++ b/src/api/utils/request_api.js
@@ -1,0 +1,112 @@
+/**
+ * Request is a a custom Network Layer.  Its main benefits of using it over fetch include
+ * a longer chain of promises which allows us to write error handling code all in one place.
+ * Request will give json back or some standard, meaningful error so that the errors and parsing
+ * don't have to be handled higher up in the call stack.
+ */
+
+class Request {
+  static headers() {
+    return {
+      'Content-Type': 'application/json'
+    }
+  }
+
+  static get(url) {
+    return this.fetchWrapper(url, null, 'GET')
+  }
+  static post(url, params) {
+    return this.fetchWrapper(url, params, 'POST')
+  }
+
+  static isJSON(response) {
+    // returns true if response is of type JSON
+    const contentType = response.headers.get('content-type');
+
+    return contentType && contentType.includes('application/json');
+  }
+
+  /**
+   * @param {Response} response
+   * @return {Promise} 
+   */
+  static parseResponseBody(response) {
+    if (this.isJSON(response)) {
+      return response.json();
+    }
+
+    return response.text();
+  }
+
+  /**
+   * @param {String} url
+   * @param {Object?} params
+   * @param {String} verb
+   * @return {Promise} 
+   */
+  static fetchWrapper(url, params, verb) {
+
+    // for logging/debugging
+    console.log(`${verb} ${url}`, params);
+
+    // baseURL is URL without params
+    // useful if settings/filters are in URL
+    const baseURL = url.split('?')[0];
+
+    // options are the complicated object of options that are passed in a fetch response
+    // another benefit of abstracting this portion away
+    let options = Object.assign({ method: verb }, params ? { body: JSON.stringify(params) } : null);
+    options.headers = Request.headers();
+
+    let fetchResponse, fetchStatusCode, errorResponse;
+
+    return fetch(url, options).then(response => {
+      fetchResponse = response;
+      fetchStatusCode = response.status;
+
+      // success, simply return promise of parsed response
+      if (fetchStatusCode === 200 || fetchStatusCode === 201) {
+        return Request.parseResponseBody(fetchResponse);
+      }
+      else {
+        // throw errors if bad status
+        return Request.parseResponseBody(response).then(body => {
+          errorResponse = body;
+          throw new Error(`${url} failed status=${response.status} errorResponse=${errorResponse}`);
+        })
+        .catch(() => {
+          // catch error if parseResponseBody throws an error
+          throw new Error(`${url} failed status=${response.status}`);
+        });
+      }
+    })
+    .catch(exception => {
+      // catch JSE
+
+      // give details on what the error was so it doesn't have to be deciphered up the call stack
+      let errorType;
+      if (!fetchResponse) {
+        // no response at all
+        errorType = 'NETWORK';
+      }
+      else if (fetchStatusCode === 200) {
+        errorType = 'PARSE RESPONSE';
+      } else {
+        // generic error
+        errorType = 'API CALL';
+      }
+
+      // a meaningful error
+      const errorDetail = {
+        errorType,
+        errorResponse,
+        exception: exception.message,
+        statusCode: fetchStatusCode
+      };
+
+      return Promise.reject(errorDetail);
+    });
+  }
+}
+
+export default Request;

--- a/src/api/utils/request_api.js
+++ b/src/api/utils/request_api.js
@@ -57,10 +57,7 @@ class Request {
     }
 
     if (params) {
-      options = {
-        ...options,
-        body: JSON.stringify(params)
-      }
+      options.body = JSON.stringify(params);
     }
 
     let fetchResponse, fetchStatusCode, errorResponse;

--- a/src/api/utils/request_api.js
+++ b/src/api/utils/request_api.js
@@ -49,14 +49,19 @@ class Request {
     // for logging/debugging
     console.log(`${verb} ${url}`, params);
 
-    // baseURL is URL without params
-    // useful if settings/filters are in URL
-    const baseURL = url.split('?')[0];
-
     // options are the complicated object of options that are passed in a fetch response
     // another benefit of abstracting this portion away
-    let options = Object.assign({ method: verb }, params ? { body: JSON.stringify(params) } : null);
-    options.headers = Request.headers();
+    let options = {
+      method: verb,
+      headers: Request.headers()
+    }
+
+    if (params) {
+      options = {
+        ...options,
+        body: JSON.stringify(params)
+      }
+    }
 
     let fetchResponse, fetchStatusCode, errorResponse;
 

--- a/src/containers/landing.js
+++ b/src/containers/landing.js
@@ -22,8 +22,8 @@ class Landing extends React.Component {
     const payload = {
       firstName: "the last",
       lastName: "boob",
-      email: "boob30@boob.com",
-      username: "blah71",
+      email: "boob40@boob.com",
+      username: "blah72",
       password: "password"
     }
 

--- a/src/containers/landing.js
+++ b/src/containers/landing.js
@@ -4,12 +4,36 @@ import { push } from 'react-router-redux';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
+import AdminClient from '../api/admin_client/index'
+
 import Button from '../components/Button';
 
 class Landing extends React.Component {
   constructor(props) {
     super(props);
     this.state = {};
+
+    this.createAdmin = this.createAdmin.bind(this);
+  }
+
+  createAdmin() {
+    // for testing
+
+    const payload = {
+      firstName: "the last",
+      lastName: "boob",
+      email: "boob29@boob.com",
+      username: "blah70",
+      password: "password"
+    }
+
+    AdminClient.getSingleton().createAdmin(payload)
+      .then(response => {
+        console.log('createAdmin', response);        
+      })
+      .catch(error => {
+        console.log('createAdmin failed', error);
+      })
   }
 
   render() {
@@ -22,6 +46,8 @@ class Landing extends React.Component {
     return (
       <div className="display">
         <Button label="see projects" color="primary" onClick={onClickView} />
+
+        <Button label="create an admin" color="primary" onClick={this.createAdmin} />
       </div>
     );
   }

--- a/src/containers/landing.js
+++ b/src/containers/landing.js
@@ -22,8 +22,8 @@ class Landing extends React.Component {
     const payload = {
       firstName: "the last",
       lastName: "boob",
-      email: "boob29@boob.com",
-      username: "blah70",
+      email: "boob30@boob.com",
+      username: "blah71",
       password: "password"
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -677,7 +677,7 @@ babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
 
-babel-plugin-syntax-class-properties@^6.8.0:
+babel-plugin-syntax-class-properties@^6.13.0, babel-plugin-syntax-class-properties@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz#d7eb23b79a317f8543962c505b827c7d6cac27de"
 
@@ -713,7 +713,7 @@ babel-plugin-transform-async-to-generator@^6.22.0:
     babel-plugin-syntax-async-functions "^6.8.0"
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-class-properties@6.24.1:
+babel-plugin-transform-class-properties@6.24.1, babel-plugin-transform-class-properties@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz#6a79763ea61d33d36f37b611aa9def81a81b46ac"
   dependencies:


### PR DESCRIPTION
# What

Wrote a (partially incomplete, but usable) network layer in `api/utils/request_api.js`  

* Request is a custom "Network Layer" (added quotes bc @wongbryan).  Its main benefits of using it over fetch include a longer chain of promises which allows us to write error handling code all in one place.  Request will give json back, or text, or some standard, meaningful error so that the errors and parsing don't have to be handled higher up in the call stack.

Began writing an API Client for the admin service in `api/adminClient/index.js`
* All requests related to our Admin service will pass through here.  The API Layer utilizes custom `Request` class to make requests.
* Decided to implement this API Client as a singleton

# Dependencies

Added some babel dependencies to support class/static javascript syntax.  make sure you `yarn install`.

@jl98 @xualexander @wongbryan @simonzhow @styvone 